### PR TITLE
feat: code-review/code-review-fixのPR/MR書き込み手順を改善

### DIFF
--- a/.claude/skills/code-review-fix/SKILL.md
+++ b/.claude/skills/code-review-fix/SKILL.md
@@ -59,7 +59,8 @@ flowchart TD
     I -->|❌| K[修正を調整]
     K --> H
     J --> L[コミット]
-    L --> M[完了レポート → 再レビューへ]
+    L --> M[PR/MR書き込み]
+    M --> N[完了レポート → 再レビューへ]
 ```
 
 ## 出力
@@ -67,6 +68,15 @@ flowchart TD
 修正完了後、各指摘のステータス（`fixed` / `disputed`）と対応内容を出力し、コミット・完了レポートを作成します。
 
 📖 出力例・ステータス遷移・コミットテンプレート・完了レポートは [references/output-templates.md](references/output-templates.md) を参照
+
+## PR/MR書き込み
+
+コミット後、修正結果をMR/PRに反映:
+- 完了レポートをMR/PRコメントとして投稿
+- 各指摘のレビュースレッドに対応結果（修正済み/反論）を返信
+- 書き込み後にAPIで内容を再取得し確認
+
+📖 詳細は [references/pr-result-writing.md](references/pr-result-writing.md) を参照
 
 ## 注意事項
 

--- a/.claude/skills/code-review-fix/references/pr-result-writing.md
+++ b/.claude/skills/code-review-fix/references/pr-result-writing.md
@@ -1,0 +1,171 @@
+# PR/MR修正結果書き込み手順
+
+code-review-fixの修正結果をMR/PRに書き込む手順。
+
+> [!CAUTION]
+> **Shell展開防止（必須）**
+> - `--body "$VAR"` や heredoc/echo でのbody構築は **禁止**（shell展開でMarkdownが破壊される）
+> - GitHub: 必ず `--body-file` でファイル経由で渡す
+> - GitLab: 必ず `create`ツールでPythonスクリプトを作成し、`requests` ライブラリ経由で渡す
+
+## 書き込みタイミング
+
+```
+指摘対応完了 → コミット → 1. 完了レポートコメント投稿 → 2. レビュースレッドへ返信 → 3. 書き込み確認
+```
+
+## 1. 修正結果コメント投稿
+
+完了レポート（[output-templates.md](output-templates.md) の形式）をMR/PRコメントとして投稿。
+
+### GitHub
+
+```bash
+PR_NUMBER=$(gh pr view --json number -q '.number')
+# 完了レポートをファイルとして作成（createツールまたはeditツールで作成済み）
+gh pr comment "$PR_NUMBER" --body-file "docs/{target}/code-review/fix-report.md"
+```
+
+### GitLab
+
+`create`ツールでPythonスクリプトを作成し、`bash`ツールで実行する。
+
+```python
+# post_fix_report.py — createツールで作成
+import requests, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+report_file = sys.argv[2]
+
+with open(report_file, "r") as f:
+    report_content = f.read()
+
+response = requests.post(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes",
+    headers={"PRIVATE-TOKEN": token},
+    json={"body": report_content}
+)
+response.raise_for_status()
+print(f"Fix report posted: note_id={response.json()['id']}")
+```
+
+```bash
+python post_fix_report.py "$MR_IID" "docs/{target}/code-review/fix-report.md"
+```
+
+## 2. レビュースレッドへの返信
+
+各指摘に対する修正内容/反論をレビュースレッドに個別返信する。
+
+### 返信フォーマット
+
+修正済みの場合:
+```markdown
+**対応: 修正済み** ✅
+{fixed_description}
+コミット: {commit_sha}
+```
+
+反論の場合:
+```markdown
+**対応: 反論** ⚠️
+{dispute_reason}
+```
+
+### GitHub
+
+`gh api` でレビューコメントに返信する。返信内容はファイル経由で渡す。
+
+```bash
+# 返信内容をJSONファイルとして作成（createツールで作成）
+# reply-CR-001.json:
+#   {"body": "**対応: 修正済み** ✅\nAPIレスポンスを { data, error } 形式に修正\nコミット: abc1234"}
+
+# レビューコメントへの返信（Pull Request Review Comment Reply API）
+gh api \
+  -X POST \
+  "/repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+  --input reply-CR-001.json
+```
+
+### GitLab
+
+MRディスカッションノートに返信する。`create`ツールでPythonスクリプトを作成し実行。
+
+```python
+# reply_to_discussion.py — createツールで作成
+import requests, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+discussion_id = sys.argv[2]
+reply_file = sys.argv[3]
+
+with open(reply_file, "r") as f:
+    reply_content = f.read()
+
+response = requests.post(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions/{discussion_id}/notes",
+    headers={"PRIVATE-TOKEN": token},
+    json={"body": reply_content}
+)
+response.raise_for_status()
+print(f"Reply posted: note_id={response.json()['id']}")
+```
+
+```bash
+# 各指摘のdiscussion_idに対して返信
+python reply_to_discussion.py "$MR_IID" "$DISCUSSION_ID" reply-CR-001.md
+```
+
+## 3. 書き込み後の内容確認
+
+書き込み後、APIで内容を再取得し、意図通りに反映されたか確認する。
+
+### GitHub
+
+```bash
+# 最新コメントを確認
+gh pr view "$PR_NUMBER" --json comments --jq '.comments[-1].body' | head -5
+
+# レビュー返信を確認（特定のコメントIDで取得）
+gh api "/repos/{owner}/{repo}/pulls/comments/${COMMENT_ID}" --jq '.body' | head -3
+```
+
+### GitLab
+
+```python
+# verify_fix_writing.py — createツールで作成
+import requests, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+
+# 最新のノート（コメント）を確認
+response = requests.get(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes",
+    headers={"PRIVATE-TOKEN": token},
+    params={"sort": "desc", "per_page": 3}
+)
+response.raise_for_status()
+notes = response.json()
+for note in notes:
+    print(f"--- note_id={note['id']} ---")
+    for line in note["body"].split("\n")[:3]:
+        print(line)
+    print()
+```
+
+### 不一致時のリトライ
+
+確認で不一致が検出された場合:
+1. 書き込み内容のファイルを再確認
+2. API呼び出しを再実行（最大2回リトライ）
+3. 2回リトライしても不一致の場合、エラーとして報告

--- a/.claude/skills/code-review/references/mr-pr-result-writing.md
+++ b/.claude/skills/code-review/references/mr-pr-result-writing.md
@@ -2,10 +2,16 @@
 
 code-reviewの結果をMR/PRに書き込む手順。
 
+> [!CAUTION]
+> **Shell展開防止（必須）**
+> - `--body "$VAR"` や heredoc/echo でのbody構築は **禁止**（shell展開でMarkdownが破壊される）
+> - GitHub: 必ず `--body-file` でファイル経由で渡す
+> - GitLab: 必ず `create`ツールでPythonスクリプトを作成し、`requests` ライブラリ経由で渡す
+
 ## 書き込みタイミング
 
 ```
-レビュー完了 → 1. コメント投稿 → 2. description更新 → 3. [全指摘解消時] draft解除
+レビュー完了 → 1. コメント投稿 → 2. description更新 → 3. 書き込み確認 → 4. [全指摘解消時] draft解除
 ```
 
 ## 1. レビュー結果コメント投稿
@@ -21,9 +27,32 @@ gh pr comment "$PR_NUMBER" --body-file "docs/{target}/code-review/round-NN-summa
 
 ### GitLab
 
+`create`ツールでPythonスクリプトを作成し、`bash`ツールで実行する。
+
+```python
+# post_mr_comment.py — createツールで作成
+import requests, json, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+comment_file = sys.argv[2]
+
+with open(comment_file, "r") as f:
+    comment_content = f.read()
+
+response = requests.post(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes",
+    headers={"PRIVATE-TOKEN": token},
+    json={"body": comment_content}
+)
+response.raise_for_status()
+print(f"Comment posted: note_id={response.json()['id']}")
+```
+
 ```bash
-# POST /projects/:id/merge_requests/:mr_iid/notes
-# body: round-NN-summary.md の内容
+python post_mr_comment.py "$MR_IID" "docs/{target}/code-review/round-NN-summary.md"
 ```
 
 ## 2. Descriptionチェックリスト更新
@@ -47,17 +76,43 @@ MR/PR descriptionのチェックボックスをレビュー結果に基づいて
 
 ```bash
 # 現在のdescriptionを取得
-BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
-# チェックボックスを更新（sed等で置換）
-# 更新後のdescriptionを設定
-gh pr edit "$PR_NUMBER" --body "$UPDATED_BODY"
+gh pr view "$PR_NUMBER" --json body -q '.body' > pr-body-current.md
+
+# pr-body-current.md の内容を読み取り、チェックボックスを更新した内容を
+# editツールまたはcreateツールで pr-body-updated.md に書き出す
+
+# 更新後のdescriptionをファイル経由で設定
+gh pr edit "$PR_NUMBER" --body-file pr-body-updated.md
 ```
 
 #### GitLab
 
+`create`ツールでPythonスクリプトを作成し、`bash`ツールで実行する。
+
+```python
+# update_mr_description.py — createツールで作成
+import requests, json, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+description_file = sys.argv[2]
+
+with open(description_file, "r") as f:
+    updated_description = f.read()
+
+response = requests.put(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}",
+    headers={"PRIVATE-TOKEN": token},
+    json={"description": updated_description}
+)
+response.raise_for_status()
+print(f"Description updated: mr_iid={mr_iid}")
+```
+
 ```bash
-# PUT /projects/:id/merge_requests/:mr_iid
-# description: 更新後のdescription
+python update_mr_description.py "$MR_IID" pr-body-updated.md
 ```
 
 ### AI+人間チェック項目
@@ -71,7 +126,65 @@ AIが分析結果と根拠を記入（チェックボックスはonにしない 
   > AI分析: 既存APIの変更なし、後方互換性維持
 ```
 
-## 3. Draft解除
+## 3. 書き込み後の内容確認
+
+書き込み後、APIで内容を再取得し、意図通りに反映されたか確認する。
+
+### GitHub
+
+```bash
+# コメント確認: 最新コメントを取得して内容を確認
+gh pr view "$PR_NUMBER" --json comments --jq '.comments[-1].body' | head -5
+
+# description確認: 更新後のbodyを取得して確認
+gh pr view "$PR_NUMBER" --json body -q '.body' > pr-body-verify.md
+# pr-body-verify.md の内容を確認し、チェックボックスが正しく更新されているか検証
+```
+
+### GitLab
+
+```python
+# verify_mr_content.py — createツールで作成
+import requests, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+
+# MR description を再取得
+response = requests.get(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}",
+    headers={"PRIVATE-TOKEN": token}
+)
+response.raise_for_status()
+mr = response.json()
+print("=== Description (先頭5行) ===")
+for line in mr["description"].split("\n")[:5]:
+    print(line)
+
+# 最新のノート（コメント）を確認
+response = requests.get(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes",
+    headers={"PRIVATE-TOKEN": token},
+    params={"sort": "desc", "per_page": 1}
+)
+response.raise_for_status()
+notes = response.json()
+if notes:
+    print(f"\n=== Latest note (id={notes[0]['id']}) ===")
+    for line in notes[0]["body"].split("\n")[:5]:
+        print(line)
+```
+
+### 不一致時のリトライ
+
+確認で不一致が検出された場合:
+1. 書き込み内容のファイルを再確認
+2. API呼び出しを再実行（最大2回リトライ）
+3. 2回リトライしても不一致の場合、エラーとして報告
+
+## 4. Draft解除
 
 全指摘が解消（code-review-fixループ完了）された場合のみdraft解除。
 
@@ -89,9 +202,35 @@ gh pr ready "$PR_NUMBER"
 
 ### GitLab
 
-```bash
-# タイトルから "Draft: " プレフィックスを除去
-# PUT /projects/:id/merge_requests/:mr_iid
+```python
+# undraft_mr.py — createツールで作成
+import requests, os, sys
+
+gitlab_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+token = os.environ["GITLAB_TOKEN"]
+project_id = os.environ["CI_PROJECT_ID"]
+mr_iid = sys.argv[1]
+
+# 現在のタイトルを取得
+response = requests.get(
+    f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}",
+    headers={"PRIVATE-TOKEN": token}
+)
+response.raise_for_status()
+title = response.json()["title"]
+
+# "Draft: " プレフィックスを除去
+if title.startswith("Draft: "):
+    new_title = title[len("Draft: "):]
+    response = requests.put(
+        f"{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{mr_iid}",
+        headers={"PRIVATE-TOKEN": token},
+        json={"title": new_title}
+    )
+    response.raise_for_status()
+    print(f"Draft removed: {new_title}")
+else:
+    print(f"Already not draft: {title}")
 ```
 
 ## 統合MR/PRの場合


### PR DESCRIPTION
## 概要
code-reviewとcode-review-fixスキルのPR/MR書き込み手順を改善。

## 対応内容
- **mr-pr-result-writing.md**: GitLabセクション完成（Python requests方式）、`--body-file`パターン、書き込み確認ステップ、Shell展開防止注意事項追加
- **pr-result-writing.md**: 新規作成 — code-review-fixの修正結果コメント投稿・レビュースレッド返信手順
- **code-review-fix/SKILL.md**: 処理フローにPR/MR書き込みステップ追加

Closes #26